### PR TITLE
Add more unit tests

### DIFF
--- a/tests/unit/async-utils.spec.ts
+++ b/tests/unit/async-utils.spec.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withTimeout } from '../../src/lib/async-utils';
+
+// Basic unit tests for withTimeout utility
+
+test('withTimeout resolves before timeout', async () => {
+  const result = await withTimeout(Promise.resolve('ok'), 1000);
+  assert.strictEqual(result, 'ok');
+});
+
+test('withTimeout rejects after timeout', async () => {
+  try {
+    await withTimeout(new Promise(res => setTimeout(res, 50)), 10);
+    assert.fail('Expected timeout');
+  } catch (e) {
+    assert.match(String(e), /Operation timed out/);
+  }
+});

--- a/tests/unit/email.spec.ts
+++ b/tests/unit/email.spec.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.RESEND_API_KEY = '';
+process.env.EMAIL_FROM = '';
+const { sendPasswordResetEmail } = await import('../../src/services/email');
+
+const origInfo = console.info;
+const messages: string[] = [];
+console.info = (msg: string) => { messages.push(msg); };
+
+await sendPasswordResetEmail('a@example.com', 'https://example.com/reset');
+console.info = origInfo;
+
+test('sendPasswordResetEmail logs simulation when disabled', () => {
+  assert.ok(messages.some(m => m.includes('[Email Simulation]')));
+});

--- a/tests/unit/error-handler.spec.ts
+++ b/tests/unit/error-handler.spec.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isError, getErrorMessage } from '../../src/lib/error-handler';
+
+test('isError returns true for Error objects', () => {
+  assert.ok(isError(new Error('boom')));
+});
+
+test('isError returns false for non Error', () => {
+  assert.equal(isError('no'), false);
+});
+
+test('getErrorMessage handles strings', () => {
+  assert.equal(getErrorMessage('msg'), 'msg');
+});
+
+
+test('getErrorMessage handles objects', () => {
+  const obj = { foo: 'bar' } as unknown as Error;
+  const msg = getErrorMessage(obj);
+  assert.ok(msg.includes('foo'));
+});

--- a/tests/unit/genkit.spec.ts
+++ b/tests/unit/genkit.spec.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.GOOGLE_API_KEY = '';
+const { testGenkitConnection } = await import('../../src/services/genkit');
+
+test('testGenkitConnection fails when not configured', async () => {
+  const result = await testGenkitConnection();
+  assert.equal(result.isConfigured, false);
+  assert.equal(result.success, false);
+});

--- a/tests/unit/logger.spec.ts
+++ b/tests/unit/logger.spec.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { logger } from '../../src/lib/logger';
+
+test('logger.info prints message', () => {
+  const msgs: string[] = [];
+  const orig = console.info;
+  console.info = (msg: string) => { msgs.push(msg); };
+  logger.info('hello');
+  console.info = orig;
+  assert.ok(msgs.some(m => m.includes('hello')));
+});

--- a/tests/unit/redis.spec.ts
+++ b/tests/unit/redis.spec.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.REDIS_URL = '';
+const redisModule = await import('../../src/lib/redis');
+const { rateLimit, isRedisEnabled } = redisModule;
+
+test('rateLimit returns open state when redis disabled', async () => {
+  assert.equal(isRedisEnabled, false);
+  const result = await rateLimit('id', 'action', 5, 60);
+  assert.equal(result.limited, false);
+  assert.equal(result.remaining, 5);
+});
+
+test('rateLimit failClosed when redis disabled', async () => {
+  const result = await rateLimit('id', 'action', 5, 60, true);
+  assert.equal(result.limited, true);
+  assert.equal(result.remaining, 0);
+});

--- a/tests/unit/use-toast.spec.ts
+++ b/tests/unit/use-toast.spec.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { reducer } from '../../src/hooks/use-toast';
+
+const baseToast = { id: '1', title: 'hi', open: true } as any;
+
+test('reducer adds toast', () => {
+  const state = { toasts: [] };
+  const next = reducer(state, { type: 'ADD_TOAST', toast: baseToast });
+  assert.equal(next.toasts.length, 1);
+});
+
+test('reducer dismisses toast', () => {
+  const state = { toasts: [baseToast] };
+  const next = reducer(state, { type: 'DISMISS_TOAST', toastId: '1' });
+  assert.equal(next.toasts[0].open, false);
+});

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cn, linearRegression, formatCentsAsCurrency } from '../../src/lib/utils';
+
+test('cn merges class names', () => {
+  assert.equal(cn('foo', { bar: true, baz: false }), 'foo bar');
+});
+
+test('linearRegression calculates slope and intercept', () => {
+  const data = [ { x: 1, y: 2 }, { x: 2, y: 4 } ];
+  const result = linearRegression(data);
+  assert.equal(result.slope.toFixed(1), '2.0');
+  assert.equal(result.intercept.toFixed(1), '0.0');
+});
+
+test('formatCentsAsCurrency handles values', () => {
+  assert.equal(formatCentsAsCurrency(1234), '$12.34');
+  assert.equal(formatCentsAsCurrency(null), '$0.00');
+  assert.equal(formatCentsAsCurrency(undefined), '$0.00');
+});


### PR DESCRIPTION
## Summary
- add tests for utils helpers
- add tests for redis fallback
- add tests for email service fallback

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb929fba48328b43be5038be7a566